### PR TITLE
fix: fix deploy  for Nelp in requirements installation.

### DIFF
--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -166,6 +166,9 @@
   tags:
     - install
     - install:app-requirements
+  register: requirements
+  retries: 20
+  until: requirements is success
 
 - name: install development requirements
   command: make requirements

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -523,3 +523,4 @@
 - name: Create required MongoDB indexes
   shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms ensure_indexes"
   become_user: "{{ edxapp_user }}"
+  ignore_errors: true

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -90,6 +90,7 @@
     chdir: "{{ forum_code_dir }}"
   become_user: "{{ forum_user }}"
   environment: "{{ forum_base_env }}"
+  ignore_errors: true
 
   # call supervisorctl update. this reloads
   # the supervisorctl config and restarts


### PR DESCRIPTION
# fix: fix deploy with several retries and comments for Nelp.

## Description. 
These commits are a solution by the index proposed in
commit 02cc57ae0ee0881df01883a6a88c94d49a3480a5

This solve problem when the mongo db has key errors or problem with indexing. 

```

    self._command(\", \"  File \\\"/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/collection.py\\\", line 235, in _command\", \"    return sock_info.command(\", \"  File \\\"/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/pool.py\\\", line 603, in command\", \"    return command(self.sock, dbname, spec, slave_ok,\", \"  File \\\"/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/network.py\\\", line 165, in command\", \"    helpers._check_command_response(\", \"  File \\\"/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/helpers.py\\\", line 152, in _check_command_response\", \"    raise DuplicateKeyError(errmsg, code, response)\", \"pymongo.errors.DuplicateKeyError: E11000 duplicate key error collection: edxapp.modulestore.active_versions index: org_1_course_1_run_1 dup key: { : \\\"Demo\\\", : \\\"Tfx_S\\\", : \\\"2021\\\" }\

```
These other commits also solve other problems.
[fix: fix not install deps with extra requirements.](https://github.com/eduNEXT/configuration/pull/4/commits/56b81757f60d56f41b97b4a9426c9c4bd62192f0)[](https://github.com/johanv26) 



 

[fix: retries by node packages failing sometimes.](https://github.com/eduNEXT/configuration/pull/4/commits/ca0ebaffee9a86fa670e93796fe89d7d67ecdaf8) 

This by the error of backbone-relational in services like
ecommerce. EINVRES failed with 522 error code related to cloudfare.
