### PR TITLE
Scorm proxy 

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -125,6 +125,24 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_cms_app;
   }
 
+  # Proxy implemented to be able to load scorm's iframe on the same site and avoid cross-site restrictions
+  location /scorm-xblock {
+    proxy_http_version     1.1;
+    proxy_set_header       Connection "";
+    proxy_set_header       Authorization '';
+    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.s3.eu-west-1.amazonaws.com;
+    proxy_hide_header      x-amz-id-2;
+    proxy_hide_header      x-amz-request-id;
+    proxy_hide_header      x-amz-meta-server-side-encryption;
+    proxy_hide_header      x-amz-server-side-encryption;
+    proxy_hide_header      Set-Cookie;
+    proxy_ignore_headers   Set-Cookie;
+    proxy_intercept_errors on;
+    add_header             Cache-Control max-age=31536000;
+    rewrite /scorm-xblock(.*) $1 break;
+    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.s3.eu-west-1.amazonaws.com;
+  }
+
   # The api is accessed using OAUTH2 which
   # uses the authorization header so we can't have
   # basic auth on it as well.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -126,11 +126,11 @@ error_page {{ k }} {{ v }};
   }
 
   # Proxy implemented to be able to load scorm's iframe on the same site and avoid cross-site restrictions
-  location /scorm-xblock {
+  location /nginx-scorm-proxy {
     proxy_http_version     1.1;
     proxy_set_header       Connection "";
     proxy_set_header       Authorization '';
-    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.s3.eu-west-1.amazonaws.com;
+    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EOX_SCORM_PROXY_HOST }};
     proxy_hide_header      x-amz-id-2;
     proxy_hide_header      x-amz-request-id;
     proxy_hide_header      x-amz-meta-server-side-encryption;
@@ -139,8 +139,8 @@ error_page {{ k }} {{ v }};
     proxy_ignore_headers   Set-Cookie;
     proxy_intercept_errors on;
     add_header             Cache-Control max-age=31536000;
-    rewrite /scorm-xblock(.*) $1 break;
-    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.s3.eu-west-1.amazonaws.com;
+    rewrite /nginx-scorm-proxy(.*) $1 break;
+    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EOX_SCORM_PROXY_HOST }};
   }
 
   # The api is accessed using OAUTH2 which

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -130,7 +130,7 @@ error_page {{ k }} {{ v }};
     proxy_http_version     1.1;
     proxy_set_header       Connection "";
     proxy_set_header       Authorization '';
-    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EOX_SCORM_PROXY_HOST }};
+    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EDXAPP_EOX_SCORM_PROXY_HOST }};
     proxy_hide_header      x-amz-id-2;
     proxy_hide_header      x-amz-request-id;
     proxy_hide_header      x-amz-meta-server-side-encryption;
@@ -140,7 +140,7 @@ error_page {{ k }} {{ v }};
     proxy_intercept_errors on;
     add_header             Cache-Control max-age=31536000;
     rewrite /nginx-scorm-proxy(.*) $1 break;
-    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EOX_SCORM_PROXY_HOST }};
+    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EDXAPP_EOX_SCORM_PROXY_HOST }};
   }
 
   # The api is accessed using OAUTH2 which

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -259,6 +259,24 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  # Proxy implemented to be able to load scorm's iframe on the same site and avoid cross-site restrictions
+  location /scorm-xblock {
+    proxy_http_version     1.1;
+    proxy_set_header       Connection "";
+    proxy_set_header       Authorization '';
+    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.s3.eu-west-1.amazonaws.com;
+    proxy_hide_header      x-amz-id-2;
+    proxy_hide_header      x-amz-request-id;
+    proxy_hide_header      x-amz-meta-server-side-encryption;
+    proxy_hide_header      x-amz-server-side-encryption;
+    proxy_hide_header      Set-Cookie;
+    proxy_ignore_headers   Set-Cookie;
+    proxy_intercept_errors on;
+    add_header             Cache-Control max-age=31536000;
+    rewrite /scorm-xblock(.*) $1 break;
+    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.s3.eu-west-1.amazonaws.com;
+  }
+  
   # No basic auth on the LTI provider endpoint, it does OAuth1
   location /lti_provider {
     try_files $uri @proxy_to_lms_app;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -264,7 +264,7 @@ error_page {{ k }} {{ v }};
     proxy_http_version     1.1;
     proxy_set_header       Connection "";
     proxy_set_header       Authorization '';
-    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EOX_SCORM_PROXY_HOST }};
+    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EDXAPP_EOX_SCORM_PROXY_HOST }};
     proxy_hide_header      x-amz-id-2;
     proxy_hide_header      x-amz-request-id;
     proxy_hide_header      x-amz-meta-server-side-encryption;
@@ -274,7 +274,7 @@ error_page {{ k }} {{ v }};
     proxy_intercept_errors on;
     add_header             Cache-Control max-age=31536000;
     rewrite /nginx-scorm-proxy(.*) $1 break;
-    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EOX_SCORM_PROXY_HOST }};
+    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EDXAPP_EOX_SCORM_PROXY_HOST }};
   }
   
   # No basic auth on the LTI provider endpoint, it does OAuth1

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -260,11 +260,11 @@ error_page {{ k }} {{ v }};
   }
 
   # Proxy implemented to be able to load scorm's iframe on the same site and avoid cross-site restrictions
-  location /scorm-xblock {
+  location /nginx-scorm-proxy {
     proxy_http_version     1.1;
     proxy_set_header       Connection "";
     proxy_set_header       Authorization '';
-    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.s3.eu-west-1.amazonaws.com;
+    proxy_set_header       Host {{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EOX_SCORM_PROXY_HOST }};
     proxy_hide_header      x-amz-id-2;
     proxy_hide_header      x-amz-request-id;
     proxy_hide_header      x-amz-meta-server-side-encryption;
@@ -273,8 +273,8 @@ error_page {{ k }} {{ v }};
     proxy_ignore_headers   Set-Cookie;
     proxy_intercept_errors on;
     add_header             Cache-Control max-age=31536000;
-    rewrite /scorm-xblock(.*) $1 break;
-    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.s3.eu-west-1.amazonaws.com;
+    rewrite /nginx-scorm-proxy(.*) $1 break;
+    proxy_pass https://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}.{{ EOX_SCORM_PROXY_HOST }};
   }
   
   # No basic auth on the LTI provider endpoint, it does OAuth1


### PR DESCRIPTION
Proxy created to load scorm's components in the same domain and avoid cross-site restrictions 