### PR TITLE
feat: add scorm config in nginx for performance

### DIFF
--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -63,6 +63,13 @@ http {
         ssl_prefer_server_ciphers on;
         ssl_dhparam {{ NGINX_DH_PARAMS_PATH }};
 
+        ##
+        # Scorm helpers
+        ##
+        client_max_body_size 100M;
+        proxy_read_timeout 300;
+        proxy_connect_timeout 300;
+        proxy_send_timeout 300;
 
         ##
         # Gzip Settings
@@ -85,4 +92,3 @@ http {
         include {{ nginx_conf_dir }}/*.conf;
         include {{ nginx_sites_enabled_dir }}/*;
 }
-


### PR DESCRIPTION
Configuration Pull Request
---
# Description
Config to improve scorm performance for slow connections.

# Test
Working in prod machines.
 
![2022-06-14_20-44](https://user-images.githubusercontent.com/51926076/173718642-71dfbb64-3b2f-4f81-8eee-266e54501f6a.png)

Seem it works to upload scorms, I tested in this course:
https://studio.futurex.sa/course/course-v1:EDUNEXT+cd101+2022-t3 

This helps to avoid this error.

```
ubuntu@ip-10-0-46-214:/edx/etc$ tail -f /edx/var/log/supervisor/cms-stderr.log
boto.exception.S3ResponseError: S3ResponseError: 403 Forbidden
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>AKIA5O6PSRF7VHXMLQKW</AWSAccessKeyId><StringToSign>PUT
lt7XHZXqdbMKxiUVP0ndeg==
text/javascript
Tue, 14 Jun 2022 23:03:44 GMT
x-amz-acl:private
/futurex-edxapp-production/scorm/91ef15721a074f80bee454ea3a392e89/f792c4c021da74aac780e072bf16aa0ed4987767/Etiquette/questions.js</StringToSign><SignatureProvided>9S83M6QruQHizRzH5Kz2h0UYAt0=</SignatureProvided><StringToSignBytes>50 55 54 0a 6c 74 37 58 48 5a 58 71 64 62 4d 4b 78 69 55 56 50 30 6e 64 65 67 3d 3d 0a 74 65 78 74 2f 6a 61 76 61 73 63 72 69 70 74 0a 54 75 65 2c 20 31 34 20 4a 75 6e 20 32 30 32 32 20 32 33 3a 30 33 3a 34 34 20 47 4d 54 0a 78 2d 61 6d 7a 2d 61 63 6c 3a 70 72 69 76 61 74 65 0a 2f 66 75 74 75 72 65 78 2d 65 64 78 61 70 70 2d 70 72 6f 64 75 63 74 69 6f 6e 2f 73 63 6f 72 6d 2f 39 31 65 66 31 35 37 32 31 61 30 37 34 66 38 30 62 65 65 34 35 34 65 61 33 61 33 39 32 65 38 39 2f 66 37 39 32 63 34 63 30 32 31 64 61 37 34 61 61 63 37 38 30 65 30 37 32 62 66 31 36 61 61 30 65 64 34 39 38 37 37 36 37 2f 45 74 69 71 75 65 74 74 65 2f 71 75 65 73 74 69 6f 6e 73 2e 6a 73</StringToSignBytes><RequestId>0Y3Y8QKJ0RXA4XG2</RequestId><HostId>dfwJjksw8bJE1KAEJPdvLX61BTzxFEsvKrMtp67QUc+1fVkNk/oABNoBB374X0cvQ4AWf1L4444=</HostId></Error>
[2022-06-14 23:03:45 +0000] [1520] [INFO] POST /preview/xblock/block-v1:EDUNEXT+cd3033+2022_t2+type@scorm+block@36277508ccee44b983e83fd0e86b6950/handler/scorm_set_values
2022-06-14 23:03:45,960 INFO 1520 [eox_tenant.signals] [user None] [ip None] signals.py:48 - Site studio.futurex.sa, does not use eox_tenant signals
[2022-06-14 23:05:45 +0000] [1521] [INFO] POST /preview/xblock/block-v1:EDUNEXT+cd3033+2022_t2+type@scorm+block@36277508ccee44b983e83fd0e86b6950/handler/scorm_set_values
2022-06-14 23:05:45,956 INFO 1521 [eox_tenant.signals] [user None] [ip None] signals.py:48 - Site studio.futurex.sa, does not use eox_tenant signals
^C

```